### PR TITLE
ChainScript first proto draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,47 @@ Proof of Process provides immutability and auditability of every step in the
 process.
 
 Learn more [here](https://proofofprocess.org/).
+
+## How to use
+
+ChainScript is defined with [protobuf](https://developers.google.com/protocol-buffers/)
+to provide a portable encoding.
+
+It is recommended to import this repository as a `git subtree`.
+Your application can then compile the protobuf file to types in your language
+of choice and add any helpers you need.
+
+Changes to ChainScript should be done in the current repository: clients should
+pull the latest changes with `git subtree`.
+
+## Design Choices
+
+### Stable Encoding
+
+ChainScript needs a stable encoding as it contains signatures and hashes of
+parts of the data. If a link didn't have the same hash in different languages,
+cross-platform applications wouldn't work.
+
+ChainScript only uses protobuf types that have a canonical encoding.
+That means that in particular, protobuf maps can't be used as their ordering is
+not specified by the protobuf specification and can vary depending on the
+implementation.
+
+Dynamic data (such as a link's state) is represented as bytes. It is your
+application's responsibility to use a stable byte encoding for that data.
+
+You have several options to define a stable encoding (not exhaustive):
+
+- [protobuf](https://developers.google.com/protocol-buffers/)
+- [canonical JSON](https://gibson042.github.io/canonicaljson-spec/)
+- [amino](https://github.com/tendermint/go-amino)
+- custom binary encoding
+
+### Versioning
+
+ChainScript should follow [protobuf's guidelines](https://developers.google.com/protocol-buffers/docs/proto3#updating)
+for backwards-compatible updates.
+
+ChainScript provides multiple version fields. These fields should be used by
+applications to update the dynamic parts of their data (such as a link's state)
+in a backwards-compatible way.

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -122,9 +122,9 @@ message LinkMeta {
     // (Optional) Action in the process that resulted in the link's creation.
     // Can be used to filter link search results.
     string action = 30;
-    // (Optional) Type of the link's data.
+    // (Optional) Step of the process that results from the action.
     // Can be used to help deserialize link data or filter link search results.
-    string data_type = 31;
+    string set = 31;
     // (Optional) Tags that can be used to filter link search results.
     repeated string tags = 32;
 

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -50,7 +50,7 @@ message SegmentMeta {
 // immutable ordering of your process' steps.
 message Evidence {
     // Version of the evidence format.
-    uint32 version = 1;
+    string version = 1;
 
     // Identifier of the evidence type.
     // For example, in the case of a timestamp on the Bitcoin blockchain,
@@ -72,7 +72,7 @@ message Evidence {
 // A link contains all the data that represents a process' step.
 message Link {
     // Version of the link format.
-    uint32 version = 1;
+    string version = 1;
 
     // Data representing the process' step details.
     // For backwards compatibility, you should update the link version
@@ -149,7 +149,7 @@ message LinkReference {
 // protobuf-encoded bytes.
 message Signature {
     // Version of the signature format.
-    uint32 version = 1;
+    string version = 1;
     // Signature algorithm used (for example, "EdDSA").
     string type = 2;
 

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -81,7 +81,7 @@ message Link {
     LinkMeta meta = 2;
 
     // (Optional) Signatures of configurable parts of the link.
-    repeated Signature signatures = 20;
+    repeated Signature signatures = 10;
 }
 
 // A process represents a real-world process that is shared between multiple

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -71,21 +71,17 @@ message Evidence {
 // A link is the immutable part of a segment.
 // A link contains all the data that represents a process' step.
 message Link {
-    // Version of the link format.
-    string version = 1;
-
     // Data representing the process' step details.
     // For backwards compatibility, you should update the link version
-    // when the structure/encoding of this field changes.
-    bytes data = 10;
-
+    // in meta when the structure/encoding of this field changes.
+    bytes data = 1;
     // Metadata associated to the process' step.
     // Some of this metadata is used to provide filtering options when
     // fetching links.
-    LinkMeta meta = 20;
+    LinkMeta meta = 2;
 
     // (Optional) Signatures of configurable parts of the link.
-    repeated Signature signatures = 30;
+    repeated Signature signatures = 20;
 }
 
 // A process represents a real-world process that is shared between multiple
@@ -101,33 +97,36 @@ message Process {
 // Metadata associated to a process' step.
 // Once included in a segment, this is immutable.
 message LinkMeta {
-    // Hash of the previous link (in the same process).
-    bytes prev_link_hash = 1;
-    // Priority of the link.
-    // Can be used to order and filter search results.
-    double priority = 2;
-    // References to related links (potentially in other processes).
-    repeated LinkReference refs = 3;
-
-    // A link is a step in a given process.
-    Process process = 10;
-    // A link always belongs to a specific map in that process.
-    // A map is an instance of a process.
-    string map_id = 11;
-
-    // (Optional) Action in the process that resulted in the link's creation.
-    // Can be used to filter link search results.
-    string action = 20;
-    // (Optional) Type of the link's data.
-    // Can be used to help deserialize link data or filter link search results.
-    string data_type = 21;
-    // (Optional) Tags that can be used to filter link search results.
-    repeated string tags = 22;
-
+    // Version of the link format.
+    // You can for example use the git tag of the code used to create the link.
+    string version = 1;
     // The Client ID should be set by the client code creating the link.
     // Use a unique ID that easily identifies your library, for example the
     // github url of your repository.
-    string client_id = 30;
+    string client_id = 2;
+
+    // Hash of the previous link (in the same process).
+    bytes prev_link_hash = 10;
+    // Priority of the link.
+    // Can be used to order and filter search results.
+    double priority = 11;
+    // References to related links (potentially in other processes).
+    repeated LinkReference refs = 12;
+
+    // A link is a step in a given process.
+    Process process = 20;
+    // A link always belongs to a specific map in that process.
+    // A map is an instance of a process.
+    string map_id = 21;
+
+    // (Optional) Action in the process that resulted in the link's creation.
+    // Can be used to filter link search results.
+    string action = 30;
+    // (Optional) Type of the link's data.
+    // Can be used to help deserialize link data or filter link search results.
+    string data_type = 31;
+    // (Optional) Tags that can be used to filter link search results.
+    repeated string tags = 32;
 
     // (Optional) Additional metadata needed by your business logic.
     // For backwards compatibility, you should update the link version when the

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -124,7 +124,7 @@ message LinkMeta {
     string action = 30;
     // (Optional) Step of the process that results from the action.
     // Can be used to help deserialize link data or filter link search results.
-    string set = 31;
+    string step = 31;
     // (Optional) Tags that can be used to filter link search results.
     repeated string tags = 32;
 

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -74,10 +74,10 @@ message Link {
     // Version of the link format.
     uint32 version = 1;
 
-    // State representing the process' step details.
+    // Data representing the process' step details.
     // For backwards compatibility, you should update the link version
-    // when the structure of this state changes.
-    bytes state = 10;
+    // when the structure/encoding of this field changes.
+    bytes data = 10;
 
     // Metadata associated to the process' step.
     // Some of this metadata is used to provide filtering options when
@@ -86,6 +86,16 @@ message Link {
 
     // (Optional) Signatures of configurable parts of the link.
     repeated Signature signatures = 30;
+}
+
+// A process represents a real-world process that is shared between multiple
+// independent actors.
+message Process {
+    // The name of the process.
+    string name = 1;
+
+    // The current state of the process.
+    string state = 10;
 }
 
 // Metadata associated to a process' step.
@@ -100,7 +110,7 @@ message LinkMeta {
     repeated LinkReference refs = 3;
 
     // A link is a step in a given process.
-    string process = 10;
+    Process process = 10;
     // A link always belongs to a specific map in that process.
     // A map is an instance of a process.
     string map_id = 11;
@@ -108,11 +118,16 @@ message LinkMeta {
     // (Optional) Action in the process that resulted in the link's creation.
     // Can be used to filter link search results.
     string action = 20;
-    // (Optional) Type of link.
-    // Can be used to help deserialize the state or filter link search results.
-    string type = 21;
+    // (Optional) Type of the link's data.
+    // Can be used to help deserialize link data or filter link search results.
+    string data_type = 21;
     // (Optional) Tags that can be used to filter link search results.
     repeated string tags = 22;
+
+    // The Client ID should be set by the client code creating the link.
+    // Use a unique ID that easily identifies your library, for example the
+    // github url of your repository.
+    string client_id = 30;
 
     // (Optional) Additional metadata needed by your business logic.
     // For backwards compatibility, you should update the link version when the

--- a/chainscript.proto
+++ b/chainscript.proto
@@ -1,0 +1,152 @@
+// Copyright 2017-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// ChainScript is an open standard for representing Proof of Process data.
+// Proof of Process is a protocol that allows partners to follow the execution
+// of a shared process.
+// Proof of Process provides immutability and auditability of every step in the
+// process.
+package stratumn.chainscript;
+
+option go_package = "github.com/stratumn/go-chainscript;chainscript";
+
+// A segment describes an atomic step in your process.
+message Segment {
+    // The link is the immutable part of a segment.
+    // It contains the details of the step.
+    Link link = 1;
+    // The link can be enriched with potentially mutable metadata.
+    SegmentMeta meta = 2;
+}
+
+// Segment metadata. This is the potentially mutable part of a segment.
+// It contains some invariants (hash of the immutable link) and evidences
+// for the link that can be produced after the link is created.
+message SegmentMeta {
+    // Hash of the segment's link.
+    bytes link_hash = 1;
+
+    // Evidences produced for the segment's link.
+    repeated Evidence evidences = 10;
+}
+
+// Evidences can be used to externally verify a link's existence at a given 
+// moment in time.
+// An evidence can be a proof of inclusion in a public blockchain, a timestamp
+// signed by a trusted authority or anything that you trust to provide an 
+// immutable ordering of your process' steps.
+message Evidence {
+    // Version of the evidence format.
+    uint32 version = 1;
+
+    // Identifier of the evidence type.
+    // For example, in the case of a timestamp on the Bitcoin blockchain,
+    // this would be "bitcoin".
+    string backend = 10;
+    // Instance of the backend used.
+    // For example, in the case of a timestamp on the Bitcoin blockchain,
+    // this would be the chain ID (to identify testnet from mainnet).
+    string provider = 11;
+
+    // Data that should be usable offline by any client wishing to validate
+    // the evidence.
+    // For backwards compatibility, you should update the evidence version 
+    // when the structure of this proof changes.
+    bytes proof = 20;
+}
+
+// A link is the immutable part of a segment.
+// A link contains all the data that represents a process' step.
+message Link {
+    // Version of the link format.
+    uint32 version = 1;
+
+    // State representing the process' step details.
+    // For backwards compatibility, you should update the link version
+    // when the structure of this state changes.
+    bytes state = 10;
+
+    // Metadata associated to the process' step.
+    // Some of this metadata is used to provide filtering options when
+    // fetching links.
+    LinkMeta meta = 20;
+
+    // (Optional) Signatures of configurable parts of the link.
+    repeated Signature signatures = 30;
+}
+
+// Metadata associated to a process' step.
+// Once included in a segment, this is immutable.
+message LinkMeta {
+    // Hash of the previous link (in the same process).
+    bytes prev_link_hash = 1;
+    // Priority of the link.
+    // Can be used to order and filter search results.
+    double priority = 2;
+    // References to related links (potentially in other processes).
+    repeated LinkReference refs = 3;
+
+    // A link is a step in a given process.
+    string process = 10;
+    // A link always belongs to a specific map in that process.
+    // A map is an instance of a process.
+    string map_id = 11;
+
+    // (Optional) Action in the process that resulted in the link's creation.
+    // Can be used to filter link search results.
+    string action = 20;
+    // (Optional) Type of link.
+    // Can be used to help deserialize the state or filter link search results.
+    string type = 21;
+    // (Optional) Tags that can be used to filter link search results.
+    repeated string tags = 22;
+
+    // (Optional) Additional metadata needed by your business logic.
+    // For backwards compatibility, you should update the link version when the
+    // structure of this field changes.
+    bytes data = 100;
+}
+
+// A reference to a link that can be in another process.
+message LinkReference {
+    // Hash of the referenced link.
+    bytes prev_link_hash = 1;
+    // Process containing the referenced link.
+    string process = 10;
+}
+
+// A signature of configurable parts of a link.
+// Different signature types and versions are allowed to sign different 
+// encodings of the data, but we recommend signing a hash of the 
+// protobuf-encoded bytes.
+message Signature {
+    // Version of the signature format.
+    uint32 version = 1;
+    // Signature algorithm used (for example, "EdDSA").
+    string type = 2;
+
+    // A description of the parts of the links that are signed.
+    // This should unambiguously let the verifier recompute the signed payload
+    // bytes from the link's content.
+    string payload_path = 10;
+
+    // Encoded signer's public key.
+    // For backwards compatibility, you should update the signature version
+    // or the signature type when changing the encoding used.
+    bytes public_key = 20;
+    // Signature bytes.
+    bytes signature = 21;
+}


### PR DESCRIPTION
Here is a first draft of the ChainScript proto definition.
Please read it carefully and don't hesitate to comment.

Here is how I see the upgrade path:

- We introduce and interate on this chainscript proto definition
- We create a go-chainscript and js-chainscript repo in which we compile this proto defintion and define the helper methods we currently have in js-indigocore and go-indigocore
- When we are at feature partify (or better) we update go-indigocore and js-indigocore
- Clients can then update their Indigo Core dependency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/chainscript/1)
<!-- Reviewable:end -->
