### PR TITLE
proto: linkref's hash shouldn't be a prevlinkhash

### DIFF
--- a/chainscript.proto
+++ b/chainscript.proto
@@ -138,7 +138,7 @@ message LinkMeta {
 // A reference to a link that can be in another process.
 message LinkReference {
     // Hash of the referenced link.
-    bytes prev_link_hash = 1;
+    bytes link_hash = 1;
     // Process containing the referenced link.
     string process = 10;
 }


### PR DESCRIPTION
A link reference contains the referenced link's hash, not prev_link_hash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/chainscript/7)
<!-- Reviewable:end -->
